### PR TITLE
Serve project/lib build from ng-serve instead of distributed files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,10 +18,10 @@
     ],
     "paths": {
       "angular-particle-effect-button": [
-        "dist/angular-particle-effect-button"
+        "projects/angular-particle-effect-button/src/public_api"
       ],
       "angular-particle-effect-button/*": [
-        "dist/angular-particle-effect-button/*"
+        "projects/angular-particle-effect-button/*"
       ]
     }
   }


### PR DESCRIPTION
This fixes `ng serve` to serve project  library from sources on the fly instead of the final generated distributed files.
