### PR TITLE
Allows to start a component with pHidden true #3

### DIFF
--- a/projects/angular-particle-effect-button/src/lib/angular-particle-effect-button.directive.ts
+++ b/projects/angular-particle-effect-button/src/lib/angular-particle-effect-button.directive.ts
@@ -55,6 +55,10 @@ export class ParticleEffectButtonDirective implements AfterContentInit {
       this.getFormattedOptions(),
       this.renderer
     );
+
+      if (this._pHidden) {
+          this._particles.disintegrate({duration: 0});
+      }
   }
   private getFormattedOptions(): IOption {
      return {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -77,5 +77,9 @@
 			<button class="particles-button" libParticleEffectButton (pComplete)="reset11=!reset11" pType="triangle" pEeasing="easeOutSine" [pSize]=3 pDuration=800 pParticlesAmountCoefficient=7
 			 [pSpeed]=3 pOscillationCoefficient=1 [pHidden]="hidden11" (click)="hidden11=!hidden11">Export</button>
 		</div>
-	</div> 
+		<div class="grid__item theme-1">
+			<button class="action" *ngIf="reset12" (click)="hidden12=!hidden12">Reset</button>
+			<button class="particles-button" libParticleEffectButton (pComplete)="reset12=!reset12" [pHidden]="hidden12" (click)="hidden12=!hidden12">Send</button>
+		</div>
+	</div>
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,4 +6,6 @@ import { Component } from '@angular/core';
   styleUrls:['./styles.css']
 })
 export class AppComponent {
+    public hidden12 = true;
+    public reset12 = true;
 }


### PR DESCRIPTION
Add simple fix on component initialisation to allow the start visibility to be hidden without animation. 

In fact, the component disintegrates with a duration of 0. This preserves the both libraries (angular and core) from any consequent change.

```js
if (this._pHidden) {
    this._particles.disintegrate({duration: 0});
}
```

I've added an exemple in the demo website with an hidden start status. 

Hope you'll agree and accept the PR, or I'll need to publish my own fork for my usage.
